### PR TITLE
Enable long-term statistics

### DIFF
--- a/custom_components/redfin/sensor.py
+++ b/custom_components/redfin/sensor.py
@@ -75,6 +75,11 @@ class RedfinDataSensor(SensorEntity):
             return None
 
     @property
+    def state_class(self):
+        # set state_class to 'measurement' so long-term statistics are generated
+        return STATE_CLASS_MEASUREMENT
+
+    @property
     def extra_state_attributes(self):
         """Return the state attributes."""
         attributes = {}


### PR DESCRIPTION
Set state_class to 'measurement' so long-term statistics are generated


Fixes #7 

Testing:
I made this on my local copy and noticed this sensor was now an option in the statistics card